### PR TITLE
ci: build docker image from checked-out source instead of re-cloning

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Keep the build context clean: COPY . /crabber must not pull in local
+# build artifacts (stale CMake cache), VCS metadata, or the vendored crab
+# clone (the image clones crab itself).
+.git
+.gitignore
+.DS_Store
+build/
+install/
+crab/
+*.o
+*.a

--- a/.github/workflows/test-crabber-docker.yml
+++ b/.github/workflows/test-crabber-docker.yml
@@ -21,10 +21,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Check out Repo 
-        uses: actions/checkout@v2
-        with:
-          ref: main # only checkout main
-      - name: Build crabber + run tests 
+      # Checks out the commit that triggered this run (PR head on
+      # pull_request, the pushed commit on push). The Dockerfile COPYs this
+      # tree, so the image builds exactly what CI checked out.
+      - name: Check out Repo
+        uses: actions/checkout@v4
+      - name: Build crabber + run tests
         run: docker build -t crabber -f docker/crabber.Dockerfile .

--- a/docker/crabber.Dockerfile
+++ b/docker/crabber.Dockerfile
@@ -1,7 +1,8 @@
 ########################################################
-# To build the image:
+# To build the image (run from the repo root; the build context must be the
+# repo root because the Dockerfile COPYs the source tree into the image):
 #
-# docker build -t crabber -f crabber.Dockerfile .
+# docker build -t crabber -f docker/crabber.Dockerfile .
 #
 # To load the image:
 #
@@ -15,10 +16,11 @@ FROM seahorn/buildpack-deps-seahorn:$BASE_IMAGE
 RUN cd / && rm -rf /crab && \
     git clone -b dev https://github.com/seahorn/crab crab;
 
-## Download/install crabber
-RUN cd / && rm -rf /crabber && \
-    git clone https://github.com/caballa/crabber crabber; \
-    mkdir -p /crabber/build
+## Install crabber from the build context (the checked-out source), so CI
+## builds exactly what was checked out -- including PR branches and local
+## uncommitted changes -- rather than re-cloning a published ref.
+COPY . /crabber
+RUN mkdir -p /crabber/build
 WORKDIR /crabber/build
 RUN cmake -GNinja \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \


### PR DESCRIPTION
The docker CI re-cloned crabber from GitHub main inside the build, so it never tested the checked-out commit -- PRs and branches went unvalidated, and a push could race its own build (the C++11->C++14 fix landed seconds after a run that had already cloned the pre-fix commit).

- Dockerfile: COPY . /crabber instead of git clone, so the image builds exactly what CI checked out.
- .dockerignore: keep the context clean (no stale build/ CMake cache, no vendored crab clone, no VCS metadata).
- workflow: drop `ref: main` so PRs build their own head; bump checkout@v2 -> v4 (clears the Node 20 deprecation warning).