### PR TITLE
feat: add VSCode syntax highlighting mode for CrabIR

### DIFF
--- a/vscode-mode/README.md
+++ b/vscode-mode/README.md
@@ -1,0 +1,50 @@
+# CrabIR — VSCode syntax highlighting
+
+A VSCode extension providing syntax highlighting, comment toggling, bracket
+matching and indentation for CrabIR (`*.crabir`) files. It is the VSCode
+counterpart to `emacs-mode/crabir-mode.el`.
+
+## What it highlights
+
+- Comments (`# ...`)
+- `cfg` and block labels (`start:`, `loop:`, ...)
+- String literals (`cfg("foo")`)
+- Types (`i1`, `i8`, `i16`, `i32`, `i64`, `i256`, ... any `iN`)
+- Integer literals
+- Constants / declarations (`declare`, `true`, `false`)
+- Arithmetic & logical operators (`add`, `sub`, `mul`, `sdiv`, `udiv`, `urem`,
+  `srem`, `and`, `or`, `xor`, `not`)
+- Control instructions (`if`, `else`, `goto`, `assume`, `unreachable`)
+- Verification instructions (`havoc`, `assert`) and `EXPECT_*` test macros
+- Special instructions (`call`, `ite`)
+- Casts (`trunc`, `sext`, `zext`)
+- Array/memory/region operations (`array_store`, `array_load`, `array_assign`,
+  `region_init`, `region_copy`, `region_cast`, `make_ref`, `remove_ref`,
+  `load_from_ref`, `store_to_ref`, `gep_ref`, `ref_to_int`, `int_to_ref`)
+- Intrinsics (`value_partition_start`, `value_partition_end`)
+- Global variables (`@name`)
+
+## Install (local / development)
+
+Copy or symlink this folder into your VSCode extensions directory:
+
+```sh
+# macOS / Linux
+ln -s "$(pwd)/vscode-mode" ~/.vscode/extensions/crabir-0.1.0
+```
+
+Then reload VSCode (`Developer: Reload Window`, or just restart it). Any
+`*.crabir` file will now be highlighted. You can confirm the language is active
+in the bottom-right of the status bar — it should read **CrabIR**.
+
+To try it without installing, open this folder in VSCode and press `F5` to
+launch an Extension Development Host, then open a file from `../samples/`.
+
+## Package as a `.vsix` (optional, for distribution)
+
+```sh
+npm install -g @vscode/vsce
+cd vscode-mode
+vsce package
+code --install-extension crabir-0.1.0.vsix
+```

--- a/vscode-mode/language-configuration.json
+++ b/vscode-mode/language-configuration.json
@@ -1,0 +1,32 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["comment"] }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""]
+  ],
+  "indentationRules": {
+    "increaseIndentPattern": "^\\s*[-A-Za-z$._0-9]+:\\s*(#.*)?$",
+    "decreaseIndentPattern": "^\\s*(cfg\\b|[-A-Za-z$._0-9]+:)"
+  },
+  "onEnterRules": [
+    {
+      "beforeText": "^\\s*[-A-Za-z$._0-9]+:\\s*(#.*)?$",
+      "action": { "indent": "indent" }
+    }
+  ]
+}

--- a/vscode-mode/package.json
+++ b/vscode-mode/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "crabir",
+  "displayName": "CrabIR",
+  "description": "Syntax highlighting for the CrabIR language (*.crabir files).",
+  "version": "0.1.0",
+  "publisher": "crab",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.60.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "crabir",
+        "aliases": [
+          "CrabIR",
+          "crabir"
+        ],
+        "extensions": [
+          ".crabir"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "crabir",
+        "scopeName": "source.crabir",
+        "path": "./syntaxes/crabir.tmLanguage.json"
+      }
+    ]
+  }
+}

--- a/vscode-mode/syntaxes/crabir.tmLanguage.json
+++ b/vscode-mode/syntaxes/crabir.tmLanguage.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "CrabIR",
+  "scopeName": "source.crabir",
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#cfg" },
+    { "include": "#labels" },
+    { "include": "#strings" },
+    { "include": "#test-macros" },
+    { "include": "#intrinsics" },
+    { "include": "#memory-ops" },
+    { "include": "#casts" },
+    { "include": "#control-keywords" },
+    { "include": "#verification-keywords" },
+    { "include": "#operator-keywords" },
+    { "include": "#constants" },
+    { "include": "#types" },
+    { "include": "#variables" },
+    { "include": "#numbers" },
+    { "include": "#operators" }
+  ],
+  "repository": {
+    "comments": {
+      "match": "#.*$",
+      "name": "comment.line.number-sign.crabir"
+    },
+    "cfg": {
+      "match": "\\bcfg\\b",
+      "name": "keyword.other.cfg.crabir"
+    },
+    "labels": {
+      "match": "^\\s*([-A-Za-z$._0-9]+)\\s*(:)\\s*(?=#|$)",
+      "captures": {
+        "1": { "name": "entity.name.label.crabir" },
+        "2": { "name": "punctuation.separator.label.crabir" }
+      }
+    },
+    "strings": {
+      "name": "string.quoted.double.crabir",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        { "match": "\\\\.", "name": "constant.character.escape.crabir" }
+      ]
+    },
+    "test-macros": {
+      "match": "\\bEXPECT_[A-Z_]+\\b",
+      "name": "support.function.test.crabir"
+    },
+    "intrinsics": {
+      "match": "\\b(value_partition_start|value_partition_end)\\b",
+      "name": "support.function.intrinsic.crabir"
+    },
+    "memory-ops": {
+      "match": "\\b(region_init|region_copy|region_cast|make_ref|remove_ref|load_from_ref|store_to_ref|gep_ref|ref_to_int|int_to_ref|array_store|array_load|array_assign)\\b",
+      "name": "keyword.other.memory.crabir"
+    },
+    "casts": {
+      "match": "\\b(trunc|sext|zext)\\b",
+      "name": "keyword.other.cast.crabir"
+    },
+    "control-keywords": {
+      "match": "\\b(if|else|goto|assume|unreachable)\\b",
+      "name": "keyword.control.crabir"
+    },
+    "verification-keywords": {
+      "match": "\\b(havoc|assert)\\b",
+      "name": "keyword.other.verification.crabir"
+    },
+    "operator-keywords": {
+      "match": "\\b(add|sub|mul|sdiv|udiv|urem|srem|and|or|xor|not|call|ite)\\b",
+      "name": "keyword.operator.word.crabir"
+    },
+    "constants": {
+      "match": "\\b(declare|true|false)\\b",
+      "name": "constant.language.crabir"
+    },
+    "types": {
+      "match": "\\bi[0-9]+\\b",
+      "name": "storage.type.crabir"
+    },
+    "variables": {
+      "match": "@[-A-Za-z$._][-A-Za-z$._0-9]*",
+      "name": "variable.other.global.crabir"
+    },
+    "numbers": {
+      "match": "\\b-?[0-9]+\\b",
+      "name": "constant.numeric.crabir"
+    },
+    "operators": {
+      "match": "(:=|<=|>=|==|!=|<|>|\\+|-|\\*|/)",
+      "name": "keyword.operator.crabir"
+    }
+  }
+}


### PR DESCRIPTION
Adds a VSCode extension under vscode-mode/ mirroring emacs-mode/, with a TextMate grammar covering all CrabIR keyword categories, plus comment, bracket, and indentation configuration for *.crabir files.