### PR TITLE
cleanup: use make_unique and fix mis-declared deleted copy-assignment

### DIFF
--- a/include/crabber/analyzer.hpp
+++ b/include/crabber/analyzer.hpp
@@ -36,7 +36,7 @@ class CrabIrAnalyzer {
 public:
   CrabIrAnalyzer(CrabIrBuilder &crabIR, const CrabIrAnalyzerOpts &opts);
   CrabIrAnalyzer(const CrabIrAnalyzer &other) = delete;
-  CrabIrAnalyzer &operator==(const CrabIrAnalyzer &other) = delete;
+  CrabIrAnalyzer &operator=(const CrabIrAnalyzer &other) = delete;
   ~CrabIrAnalyzer();
   const CrabIrAnalyzerOpts &getOpts() const;
   void analyze();

--- a/include/crabber/crabir_builder.hpp
+++ b/include/crabber/crabir_builder.hpp
@@ -26,7 +26,7 @@ class CrabIrBuilder {
 public:
   CrabIrBuilder(std::istream &is, const CrabIrBuilderOpts &opts);
   CrabIrBuilder(const CrabIrBuilder &other) = delete;
-  CrabIrBuilder &operator==(const CrabIrBuilder &other) = delete;
+  CrabIrBuilder &operator=(const CrabIrBuilder &other) = delete;
   ~CrabIrBuilder();
   const CrabIrBuilderOpts &getOpts() const;
   bool hasCFG(const std::string &name) const;

--- a/src/analyzer.cpp
+++ b/src/analyzer.cpp
@@ -53,7 +53,7 @@ public:
 
 CrabIrAnalyzer::CrabIrAnalyzer(CrabIrBuilder &crabIR,
                                const CrabIrAnalyzerOpts &opts)
-    : m_impl(new CrabIrAnalyzerImpl(crabIR, opts)) {}
+    : m_impl(std::make_unique<CrabIrAnalyzerImpl>(crabIR, opts)) {}
 
 CrabIrAnalyzer::~CrabIrAnalyzer() {}
 

--- a/src/crabir_builder.cpp
+++ b/src/crabir_builder.cpp
@@ -21,7 +21,7 @@ class CrabIrBuilderImpl {
 public:
   CrabIrBuilderImpl(std::istream &is, const CrabIrBuilderOpts &opts);
   CrabIrBuilderImpl(const CrabIrBuilderImpl &other) = delete;
-  CrabIrBuilderImpl &operator==(const CrabIrBuilderImpl &other) = delete;
+  CrabIrBuilderImpl &operator=(const CrabIrBuilderImpl &other) = delete;
   ~CrabIrBuilderImpl();
   const CrabIrBuilderOpts &getOpts() const;
   bool hasCFG(const std::string &name) const;
@@ -33,7 +33,7 @@ public:
 };
 
 CrabIrBuilder::CrabIrBuilder(std::istream &is, const CrabIrBuilderOpts &opts)
-    : m_impl(new CrabIrBuilderImpl(is, opts)) {}
+    : m_impl(std::make_unique<CrabIrBuilderImpl>(is, opts)) {}
 
 CrabIrBuilder::~CrabIrBuilder() {}
 
@@ -89,7 +89,7 @@ void CrabIrBuilderImpl::parse() {
     }
     cfg_refs.push_back(cfg_ref_t(*cfg));
   }
-  m_callgraph = std::unique_ptr<callgraph_t>(new callgraph_t(cfg_refs));
+  m_callgraph = std::make_unique<callgraph_t>(cfg_refs);
 }
 
 const CrabIrBuilderOpts &CrabIrBuilderImpl::getOpts() const { return m_opts; }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -103,7 +103,7 @@ make_cfg(variable_factory_t &vfac, const string &name,
          unsigned &assertion_counter,
          map<unsigned, expected_result> &expected_results) {
 
-  unique_ptr<cfg_t> cfg(new cfg_t("start"));
+  unique_ptr<cfg_t> cfg = make_unique<cfg_t>("start");
   for (auto &p : body) {
     cfg->insert(p.first);
   }


### PR DESCRIPTION
Replace unique_ptr(new T(...)) constructions with std::make_unique.

Also fix the non-copyable declarations: the deleted operator was written as operator== (equality) instead of operator= (copy assignment), so the copy-assignment operator was left defaulted rather than deleted.