### PR TITLE
feat: support function declarations and calls in CrabIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,3 +69,45 @@ add_executable(crabber
 target_link_libraries(crabber PRIVATE ${CRAB_LIBS})
 install(TARGETS crabber DESTINATION bin)
 install(DIRECTORY include/crabber DESTINATION include)
+
+if (TopLevel)
+  # Run the sample CrabIR programs as tests. crabber exits non-zero when there
+  # are unexpected results, so the process exit code is the pass/fail oracle.
+  # These mirror the invocations in docker/crabber.Dockerfile.
+  enable_testing()
+
+  function(add_crabber_test test_name)
+    add_test(
+      NAME ${test_name}
+      COMMAND crabber ${ARGN}
+      WORKING_DIRECTORY ${crabber_SOURCE_DIR}/samples)
+  endfunction()
+
+  add_crabber_test(test-1  test-1.crabir  -d int)
+  add_crabber_test(test-3  test-3.crabir  -d int)
+  add_crabber_test(test-4  test-4.crabir  -d oct-snf)
+  # test-5 checks a specific invariant rather than an assertion outcome: with
+  # widening thresholds, n must be in [0, 60] at block b1. Adding an assert would
+  # make the property hold trivially, so match the printed invariant instead.
+  add_test(
+    NAME test-5
+    COMMAND sh -c "$<TARGET_FILE:crabber> test-5.crabir -d int --widening-thresholds 10 --print-invariants | grep -Fx 'b1: ({}, {n -> [0, 60]})'"
+    WORKING_DIRECTORY ${crabber_SOURCE_DIR}/samples)
+  add_crabber_test(test-6  test-6.crabir  -d int)
+  # The boxes domain is only available when Crab is built with LDD support.
+  if (CRAB_USE_LDD)
+    add_crabber_test(test-7-boxes        test-7.crabir -d boxes          --widening-delay 10)
+  endif()
+  add_crabber_test(test-7-int-set        test-7.crabir -d int-set        --widening-delay 10)
+  add_crabber_test(test-7-int-val-part   test-7.crabir -d int-val-part   --widening-delay 10)
+  add_crabber_test(test-7-zones-val-part test-7.crabir -d zones-val-part --widening-delay 10)
+  add_crabber_test(test-8  test-8.crabir  -d zones)
+  add_crabber_test(test-9  test-9.crabir  -d non-unit-oct --coefficients "4,8")
+  add_crabber_test(test-10 test-10.crabir -d int-terms)
+
+  # Function-call tests (cfg parameters + call sites).
+  add_crabber_test(test-call-1 test-call-1.crabir -d zones)
+  add_crabber_test(test-call-2 test-call-2.crabir -d zones)
+  add_crabber_test(test-call-3 test-call-3.crabir -d zones)
+  add_crabber_test(test-call-4 test-call-4.crabir -d zones)
+endif()

--- a/README.md
+++ b/README.md
@@ -47,6 +47,60 @@ cfg("foo")
    EXPECT_EQ(true, assert(x == 10):i32)
 ```
 
+# Function calls #
+
+A cfg can declare typed **input** and **output** parameters and be invoked
+from another cfg through a call site.
+
+## Declaring parameters ##
+
+Parameters are written after the cfg name as a comma-separated list of
+`name:type:direction`, where `direction` is `in` or `out`. A cfg without
+parameters keeps the old `cfg("name")` form.
+
+```
+# inc(a) returns a + 1
+cfg("inc", a:i32:in, b:i32:out)
+  start:
+   b:i32 := a + 1
+   exit
+```
+
+The set of inputs and outputs must be disjoint: the same variable cannot be
+declared both as an input and as an output.
+
+## Call sites ##
+
+A call is written with the (optional) outputs on the left-hand side and the
+inputs as arguments. As everywhere else in the language, both the outputs and
+the arguments must be typed.
+
+```
+call foo(a:i32)                         # no outputs
+b:i32 := call foo(a:i32)                # single output
+(b:i32) := call foo(a:i32)             # single output, parenthesized
+(y:i32, w:i64) := call g(x:i32, z:i64) # multiple outputs
+```
+
+Putting it together:
+
+```
+cfg("inc", a:i32:in, b:i32:out)
+  start:
+   b:i32 := a + 1
+   exit
+
+cfg("main")
+  start:
+   x:i32 := 5
+   y:i32 := call inc(x:i32)
+   EXPECT_EQ(true, assert(y == 6):i32)
+```
+
+See `samples/test-call-*.crabir` for more examples, including negative tests
+(`samples/test-call-fail-*.crabir`) that are expected to be rejected by the
+parser.
+
 # Usage #
 
 ## Command Line Interface ## 

--- a/docker/crabber.Dockerfile
+++ b/docker/crabber.Dockerfile
@@ -33,19 +33,9 @@ RUN cmake -GNinja \
     cmake --build . --target ldd  && cmake .. && \
     cmake --build . --target install
 ENV PATH "/crabber/build/run/bin:$PATH"
-WORKDIR /crabber/samples
 
-# Run tests
-
-RUN crabber test-1.crabir  -d int
-RUN crabber test-3.crabir  -d int
-RUN crabber test-4.crabir  -d oct-snf
-#RUN crabber test-5.crabir  -d int --widening-thresholds 10 --print-invariants |  grep -E "^b1: \({}, {n -> \[0, 60\]}\)$"
-RUN crabber test-6.crabir  -d int
-RUN crabber test-7.crabir  -d boxes --widening-delay 10
-RUN crabber test-7.crabir  -d int-set --widening-delay 10
-RUN crabber test-7.crabir  -d int-val-part --widening-delay 10
-RUN crabber test-7.crabir  -d zones-val-part --widening-delay 10
-RUN crabber test-8.crabir -d zones
-RUN crabber test-9.crabir -d non-unit-oct --coefficients "4,8"
-RUN crabber test-10.crabir -d int-terms
+# Run tests. The sample programs are registered as CTest tests in
+# CMakeLists.txt (mirroring the invocations that used to live here); the LDD
+# tests are included because Crab is built above with -DCRAB_USE_LDD=ON.
+WORKDIR /crabber/build
+RUN ctest --output-on-failure

--- a/samples/test-call-1.crabir
+++ b/samples/test-call-1.crabir
@@ -1,0 +1,21 @@
+# Function calls: a cfg with one input and one output parameter.
+#
+# A cfg parameter list is written after the cfg name as a comma-separated
+# sequence of "name:type:direction" where direction is "in" or "out".
+#
+# A call is written with the (optional) outputs on the left-hand side and the
+# inputs as arguments:
+#     out:type := call callee(in:type)
+# A single output may be written with or without parentheses.
+
+# inc(a) returns a + 1
+cfg("inc", a:i32:in, b:i32:out)
+  start:
+   b:i32 := a + 1
+   exit
+
+cfg("main")
+  start:
+   x:i32 := 5
+   y:i32 := call inc(x:i32)
+   EXPECT_EQ(true, assert(y == 6):i32)

--- a/samples/test-call-2.crabir
+++ b/samples/test-call-2.crabir
@@ -1,0 +1,20 @@
+# Function calls: multiple inputs and multiple outputs.
+#
+# When a call has more than one output, the outputs are written as a
+# parenthesized, comma-separated list. Parameters and arguments may mix
+# bitwidths (here i32 and i64).
+
+# swap(x, z) returns (z, x)
+cfg("swap", x:i32:in, z:i64:in, y:i32:out, w:i64:out)
+  start:
+   y:i32 := x
+   w:i64 := z
+   exit
+
+cfg("main")
+  start:
+   a:i32 := 1
+   c:i64 := 2
+   (p:i32, q:i64) := call swap(a:i32, c:i64)
+   EXPECT_EQ(true, assert(p == 1):i32)
+   EXPECT_EQ(true, assert(q == 2):i64)

--- a/samples/test-call-3.crabir
+++ b/samples/test-call-3.crabir
@@ -1,0 +1,17 @@
+# Function calls: a call with no outputs (void call) and an input-only cfg.
+#
+# When a callee has no output parameters, the call is written without a
+# left-hand side:
+#     call callee(in:type)
+
+# check(p) asserts that its input is non-negative
+cfg("check", p:i32:in)
+  start:
+   EXPECT_EQ(true, assert(p >= 0):i32)
+   exit
+
+cfg("main")
+  start:
+   x:i32 := 42
+   call check(x:i32)
+   exit

--- a/samples/test-call-4.crabir
+++ b/samples/test-call-4.crabir
@@ -1,0 +1,24 @@
+# Function calls: the same callee is invoked from several call sites and the
+# callee itself has non-trivial control flow (a loop).
+
+# clamp(a) returns min(a, 10) for a non-negative a
+cfg("clamp", a:i32:in, b:i32:out)
+  start:
+   b:i32 := a
+   goto loop
+  loop:
+   if (b <= 10):i32 goto out else goto dec
+  dec:
+   b:i32 := b - 1
+   goto loop
+  out:
+   exit
+
+cfg("main")
+  start:
+   x:i32 := 3
+   u:i32 := call clamp(x:i32)
+   EXPECT_EQ(true, assert(u <= 10):i32)
+   y:i32 := 100
+   v:i32 := call clamp(y:i32)
+   EXPECT_EQ(true, assert(v <= 10):i32)

--- a/samples/test-call-fail-1.crabir
+++ b/samples/test-call-fail-1.crabir
@@ -1,0 +1,12 @@
+# NEGATIVE TEST: this program must FAIL to compile.
+#
+# A cfg's input and output parameters must be disjoint: the same variable
+# cannot be declared both as an input and as an output. Here "a" is used as
+# both, so building the function declaration is rejected with:
+#
+#   CRAB ERROR: interprocedural analysis requires that for each function
+#               its set of inputs and outputs must be disjoint.
+
+cfg("foo", a:i32:in, a:i32:out)
+  start:
+   exit

--- a/samples/test-call-fail-2.crabir
+++ b/samples/test-call-fail-2.crabir
@@ -1,0 +1,13 @@
+# NEGATIVE TEST: this program must FAIL to compile.
+#
+# A call instruction is written as "call callee(args)". Here the argument
+# list (the parentheses) is missing, so the line does not match the call
+# syntax nor any other instruction and the parser rejects it with:
+#
+#   CRAB ERROR: cannot parse    call foo at line ...
+
+cfg("main")
+  start:
+   x:i32 := 0
+   call foo
+   exit

--- a/src/crabber.cpp
+++ b/src/crabber.cpp
@@ -103,9 +103,9 @@ int main(int argc, char **argv) {
       ->required()
       ->type_name("FILE");
 
-  string domain;
-  app.add_option("-d,--domain", domain,
-                 "Select abstract domain");
+  string domain = "int";
+  auto domain_opt = app.add_option("-d,--domain", domain,
+                 "Select abstract domain (default int; see --show-domains)");
 
   bool print_domains = false;
   app.add_flag("--show-domains", print_domains, "Show all the available abstract domains");
@@ -190,6 +190,11 @@ int main(int argc, char **argv) {
   irOpts.simplify_cfg = simplify;
   irOpts.cfg_to_dot = cfg_to_dot;
   
+  if (domain_opt->count() == 0) {
+    cout << "No domain selected with -d/--domain; using default domain '"
+         << domain << "'.\n";
+  }
+
   CrabIrAnalyzerOpts anaOpts;
   bool foundDomain = false;
   for (auto dom : AbstractDomain::List) {
@@ -200,7 +205,16 @@ int main(int argc, char **argv) {
   }
 
   if (!foundDomain) {
-    CRAB_ERROR("cannot recognize domain ", domain);
+    string names;
+    for (auto const &d : AbstractDomain::List) {
+      if (!names.empty()) {
+        names += ", ";
+      }
+      names += d.name();
+    }
+    CRAB_ERROR("cannot recognize domain '", domain,
+               "'. Available domains: ", names,
+               " (use --show-domains for descriptions)");
   }
 
   if (fixed_tvpi_coefficients != "") {

--- a/src/domains/domain_defs.hpp
+++ b/src/domains/domain_defs.hpp
@@ -37,7 +37,7 @@ using namespace ikos;
 // Reduced product of boolean domain with numerical domain
 #define BOOL_NUM(DOM) flat_boolean_numerical_domain<DOM>
 // Array functor domain where the parameter domain is DOM
-#define ARRAY_FUN(DOM) array_adaptive_domain<DOM>
+#define ARRAY_FUN(DOM) array_adaptive_domain<DOM, ArrayAdaptParams>
 // Region functor domain -- the root of the hierarchy of domains.
 #define RGN_FUN(DOM) region_domain<RegionParams<DOM>>
 // Naive powerset construction
@@ -46,6 +46,11 @@ using namespace ikos;
 #define VAL_PARTITIONING(DOM) product_value_partitioning_domain<DOM>
 // Lookahead widening
 #define LOOKAHEAD_WIDENING(DOM) lookahead_widening_domain<DOM>
+
+class ArrayAdaptParams {
+  public:
+    enum { implement_inter_transformers = 1};
+};
 
 template<class BaseAbsDom>
 struct RegionParams {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -15,8 +15,15 @@
 #define QUOTE R"_(\")_"
 
 #define ANY R"_(\s*(.+?)\s*)_"
+// Like ANY but allows the empty string (used for optional argument lists).
+#define ANY_OR_EMPTY R"_(\s*(.*?)\s*)_"
 
-#define CFG_START R"_(\s*cfg)_" LPAREN  QUOTE ANY QUOTE RPAREN
+// A cfg header optionally followed by a comma-separated parameter list, e.g.
+//   cfg("foo")
+//   cfg("foo", a:i32:in, b:i32:out)
+// Group 1: cfg name. Group 2: parameter list (empty if there are no params).
+#define CFG_START                                                              \
+  R"_(\s*cfg\s*\(\s*")_" ANY R"_("\s*(?:,)_" ANY R"_()?\)\s*)_"
 
 #define CMPOP R"_(\s*(<=|<|>=|>|==|=|!=)\s*)_"
 #define CASTOP R"_(\s*(trunc|sext|zext)\s*)_"
@@ -62,6 +69,24 @@
 #define ARRAY_STORE R"_(\s*array_store)_" LPAREN VAR COMMA VAR TYPE COMMA VAR TYPE RPAREN
 #define EXIT R"_(\s*exit)_"
 
+// A direction marker for a cfg formal parameter.
+#define DIRECTION R"_(\s*(in|out)\s*)_"
+// A single cfg formal parameter: name:type:direction, e.g. a:i32:in
+// Group 1: name. Group 2: bitwidth. Group 3: direction.
+#define CFG_PARAM VAR TYPE COLON DIRECTION
+// A single typed variable: name:type, e.g. a:i32
+// Group 1: name. Group 2: bitwidth.
+#define TYPED_VAR VAR TYPE
+
+// A call site with optional outputs on the left, e.g.
+//   call foo(a:i32)
+//   b:i32 := call foo(a:i32)
+//   (b:i32) := call foo(a:i32)
+//   (y:i32, w:i64) := call g(x:i32, z:i64)
+// Group 1: outputs (empty if none). Group 2: callee name. Group 3: arguments.
+#define CALLSITE                                                               \
+  R"_(\s*(?:(.+?)\s*:=\s*)?call\s+)_" LABEL LPAREN ANY_OR_EMPTY RPAREN
+
 namespace crabber {
   
 using namespace std;
@@ -97,8 +122,47 @@ make_linear_constraint(const string &kind, const linear_expression_t &e) {
   }
 }
 
+// Parse a comma-separated list of typed variables ("a:i32, b:i64") into a
+// vector of variables. Anything between matches (commas, surrounding
+// parentheses) is ignored, so this also accepts "(a:i32, b:i64)".
+static vector<variable_t> parse_typed_var_list(const string &s,
+                                               variable_factory_t &vfac) {
+  vector<variable_t> result;
+  regex p(TYPED_VAR);
+  auto begin = sregex_iterator(s.begin(), s.end(), p);
+  auto end = sregex_iterator();
+  for (sregex_iterator it = begin; it != end; ++it) {
+    smatch m = *it;
+    auto bitwidth = std::stoi(m[2]);
+    variable_type ty((bitwidth == 1) ? BOOL_TYPE : INT_TYPE, bitwidth);
+    result.push_back(make_variable(vfac, m[1], ty));
+  }
+  return result;
+}
+
+// Parse a comma-separated cfg parameter list ("a:i32:in, b:i32:out") into
+// input and output variables.
+static void parse_function_params(const string &s, variable_factory_t &vfac,
+                                  vector<variable_t> &inputs,
+                                  vector<variable_t> &outputs) {
+  regex p(CFG_PARAM);
+  auto begin = sregex_iterator(s.begin(), s.end(), p);
+  auto end = sregex_iterator();
+  for (sregex_iterator it = begin; it != end; ++it) {
+    smatch m = *it;
+    auto bitwidth = std::stoi(m[2]);
+    variable_type ty((bitwidth == 1) ? BOOL_TYPE : INT_TYPE, bitwidth);
+    variable_t var = make_variable(vfac, m[1], ty);
+    if (m[3] == "in") {
+      inputs.push_back(var);
+    } else {
+      outputs.push_back(var);
+    }
+  }
+}
+
 static unique_ptr<cfg_t>
-make_cfg(variable_factory_t &vfac, const string &name,
+make_cfg(variable_factory_t &vfac, const string &name, const string &params,
          const vector<pair<string, vector<pair<string, unsigned>>>> &body,
          unsigned &assertion_counter,
          map<unsigned, expected_result> &expected_results) {
@@ -114,8 +178,9 @@ make_cfg(variable_factory_t &vfac, const string &name,
                                     assertion_counter, expected_results);
     }
   }
-  // TODO: parse inputs/outputs
-  function_declaration_t fdecl(name, {}, {});
+  vector<variable_t> inputs, outputs;
+  parse_function_params(params, vfac, inputs, outputs);
+  function_declaration_t fdecl(name, inputs, outputs);
   cfg->set_func_decl(fdecl);
   return cfg;
 }
@@ -148,6 +213,7 @@ pair<vector<unique_ptr<cfg_t>>, unique_ptr<map<unsigned, expected_result>>>
 parse_crabir(istream &is, variable_factory_t &vfac) {
   string line;
   string cur_cfg_name("");
+  string cur_cfg_params("");
   string cur_block("");
   vector<pair<string, unsigned>> insts;
   vector<pair<string, vector<pair<string, unsigned>>>> cur_cfg_body;
@@ -168,11 +234,13 @@ parse_crabir(istream &is, variable_factory_t &vfac) {
           cur_cfg_body.emplace_back(make_pair(cur_block, insts));
           insts.clear();
         }
-        cfgs.emplace_back(make_cfg(vfac, cur_cfg_name, cur_cfg_body,
-                                   assertion_counter, *expected_results));
+        cfgs.emplace_back(make_cfg(vfac, cur_cfg_name, cur_cfg_params,
+                                   cur_cfg_body, assertion_counter,
+                                   *expected_results));
         cur_cfg_body.clear();
       }
       cur_cfg_name = m[1];
+      cur_cfg_params = m[2];
     } else if (regex_match(line_stripped, m, regex(LABEL_DEF))) {
       // Start of a block
       if (cur_block != "") {
@@ -192,8 +260,9 @@ parse_crabir(istream &is, variable_factory_t &vfac) {
   }
 
   if (cur_cfg_name != "") {
-    cfgs.emplace_back(make_cfg(vfac, cur_cfg_name, cur_cfg_body,
-                               assertion_counter, *expected_results));
+    cfgs.emplace_back(make_cfg(vfac, cur_cfg_name, cur_cfg_params,
+                               cur_cfg_body, assertion_counter,
+                               *expected_results));
     cur_cfg_body.clear();
   }
 
@@ -394,6 +463,14 @@ void parse_instruction(const string &instruction, unsigned line_number,
   if (std::all_of(instruction_stripped.begin(), instruction_stripped.end(),
                   ::isspace)) {
     // do nothing
+  } else if (regex_match(instruction_stripped, m, regex(CALLSITE))) {
+    // function call: (outputs) := call callee(inputs)
+    // Must be matched before the assignment rules below, otherwise a
+    // single-output call would be mistaken for an assignment whose
+    // right-hand side is a linear expression.
+    vector<variable_t> outputs = parse_typed_var_list(m[1], vfac);
+    vector<variable_t> inputs = parse_typed_var_list(m[3], vfac);
+    b.callsite(m[2], outputs, inputs);
   } else if (regex_match(instruction_stripped, m, regex(HAVOC))) {
     variable_type ty(INT_TYPE, std::stoi(m[2]));
     variable_t var = make_variable(vfac, m[1], ty);


### PR DESCRIPTION
Extend the parser so a cfg can take typed input/output parameters and so call sites can be expressed as instructions.

- cfg header now accepts a parameter list: `cfg("foo", a:i32:in, b:i32:out)`. Each parameter is name:type:direction (in/out) and is used to build the cfg's function_declaration_t instead of an empty declaration.
- parse_instruction recognizes call sites:
```   
    call foo(a:i32)                        # no outputs
    b:i32 := call foo(a:i32)               # single output
    (y:i32, w:i64) := call g(x:i32, z:i64) # multiple outputs
 ```   
  emitted via `basic_block::callsite`. The call rule is matched before the assignment rules so a single-output call is not mistaken for an assignment whose rhs is a linear expression.
- add samples exercising the new syntax (test-call-1..4) plus negative tests that must fail to compile (test-call-fail-1..2).